### PR TITLE
Reorder package.json and add "files" field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,43 +1,46 @@
 {
-    "name" : "concat-map",
-    "description" : "concatenative mapdashery",
-    "version" : "0.0.1",
-    "repository" : {
-        "type" : "git",
-        "url" : "git://github.com/substack/node-concat-map.git"
-    },
-    "main" : "index.js",
-    "keywords" : [
-        "concat",
-        "concatMap",
-        "map",
-        "functional",
-        "higher-order"
-    ],
-    "directories" : {
-        "example" : "example",
-        "test" : "test"
-    },
-    "scripts" : {
-        "test" : "tape test/*.js"
-    },
-    "devDependencies" : {
-        "tape" : "~2.4.0"
-    },
-    "license" : "MIT",
-    "author" : {
-        "name" : "James Halliday",
-        "email" : "mail@substack.net",
-        "url" : "http://substack.net"
-    },
-    "testling" : {
-        "files" : "test/*.js",
-        "browsers" : {
-            "ie" : [ 6, 7, 8, 9 ],
-            "ff" : [ 3.5, 10, 15.0 ],
-            "chrome" : [ 10, 22 ],
-            "safari" : [ 5.1 ],
-            "opera" : [ 12 ]
-        }
+  "name": "concat-map",
+  "version": "0.0.1",
+  "description": "concatenative mapdashery",
+  "keywords": [
+    "concat",
+    "concatMap",
+    "functional",
+    "higher-order",
+    "map"
+  ],
+  "license": "MIT",
+  "author": {
+    "name": "James Halliday",
+    "email": "mail@substack.net",
+    "url": "http://substack.net"
+  },
+  "files": [
+    "index.js"
+  ],
+  "main": "index.js",
+  "directories": {
+    "example": "example",
+    "test": "test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git://github.com/substack/node-concat-map.git"
+  },
+  "scripts": {
+    "test": "tape test/*.js"
+  },
+  "devDependencies": {
+    "tape": "~2.4.0"
+  },
+  "testling": {
+    "files": "test/*.js",
+    "browsers": {
+      "ie": [6, 7, 8, 9],
+      "ff": [3.5, 10, 15],
+      "chrome": [10, 22],
+      "safari": [5.1],
+      "opera": [12]
     }
+  }
 }


### PR DESCRIPTION
Now npm will ignore all files except `index.js` and those stated in the [docs](https://docs.npmjs.com/files/package.json#files). This makes downloading this package a little faster for everyone.